### PR TITLE
grammar: Ensure all captures have a 'name' key

### DIFF
--- a/grammars/runoff.cson
+++ b/grammars/runoff.cson
@@ -85,7 +85,7 @@ repository:
 			begin: "!"
 			end:   "$"
 			beginCaptures:
-				0: "punctuation.definition.comment.runoff"
+				0: name: "punctuation.definition.comment.runoff"
 		},{
 			
 			# .if/.endif: Control flow


### PR DESCRIPTION
Hey there! As you may know, we use this package to provide syntax highlighting for Roff files in GitHub.

I'm currently working on improving the way we load and perform syntax highlighting on the website, and I've noticed that there's an issue in the existing grammar which is choking our new parser.

Specifically: one of the `beginCaptures` groups is missing a `name` key, which results in small rendering issues as the capture group doesn't follow the usual semantics.

The proposed change fixes the issue in a backwards-compatible way. I'd appreciate if you could merge it. Thank you!